### PR TITLE
Add official support for Trezor Hardware Wallets

### DIFF
--- a/app/scripts/directives/walletDecryptDrtv.html
+++ b/app/scripts/directives/walletDecryptDrtv.html
@@ -44,17 +44,17 @@
       Ledger Wallet
     </label>
 
-    <!-- TREZOR 
+    <!-- TREZOR -->
     <label class="radio"
            aria-flowto="aria4"
-           ng-show="ajaxReq.type=='ETH'||ajaxReq.type=='ETC'||ajaxReq.type=='ROPSTEN ETH'||ajaxReq.type=='RINKEBY ETH'||ajaxReq.type=='KOVAN ETH'||ajaxReq.type=='EXP'||ajaxReq.type=='UBQ'||ajaxReq.type=='POA'||ajaxReq.type=='TOMO'||ajaxReq.type=='ELLA'||ajaxReq.type=='EGEM'||ajaxReq.type=='CLO'||ajaxReq.type=='ETSC'||ajaxReq.type=='MUSIC'||ajaxReq.type=='GO'||ajaxReq.type=='EOSC'||ajaxReq.type=='AKROMA'||ajaxReq.type=='ESN'">
+           ng-show="ajaxReq.type=='ATH'">
       <input aria-flowto="aria4"
              type="radio"
              aria-label="Trezor Hardware Wallet"
              ng-model="walletType"
              value="trezor" />
       TREZOR
-    </label>-->
+    </label>
 
     <!-- Digital Bitbox 
     <label aria-flowto="aria5"


### PR DESCRIPTION
AtheiosChain (ATH) now supported in TREZOR ONE firmware version 1.6.3

https://blog.trezor.io/trezor-one-firmware-update-1-6-3-73894c0506d